### PR TITLE
Version 2.0.0

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__.'/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
     ->setRules([
         '@PSR2' => true,
         '@PHP70Migration' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,7 @@ build:
     analysis:
       environment:
         php:
-          version: 7.3
+          version: "7.3"
       project_setup:
         override: true
       tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ sudo: false
 
 # php compatibility
 php:
-  - 7.2
-  - 7.3
+  - "7.2"
+  - "7.3"
 
 cache:
   - directories:

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ composer require phpcfdi/cfdi-expresiones
 
 ```php
 <?php
-use PhpCfdi\CfdiExpresiones\ExpressionExtractor;
+use PhpCfdi\CfdiExpresiones\DiscoverExtractor;
 
 // creamos el extractor
-$extractor = new ExpressionExtractor();
+$extractor = new DiscoverExtractor();
 
 // abrimos el documento en un DOMDocument
 $document = new DOMDocument();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,17 +1,15 @@
 # CHANGELOG
 
-## About SemVer
+## Version 2.0.0 2019-03-28
 
-In summary, [SemVer](https://semver.org/) can be viewed as ` Breaking . Feature . Fix `, where:
-
-- Breaking version = includes incompatible changes to the API
-- Feature version = adds new feature(s) in a backwards-compatible manner
-- Fix version = includes backwards-compatible bug fixes
-
-**Non breaking changes (doesn't apply any of the SemVer rules)**
-
-- Version `0.x.x`
-- Library elements with annotation `@internal` doesn't apply any of the SemVer rules
+- Allows to create an expression with format fixes from specific types
+- Change `ExpressionExtractorInterface` to add `public function format(array $values): string`
+- Give a unique name for extractors, so when discovering by type can obtain an item
+- Change `ExpressionExtractorInterface` to add `public function uniqueName(): string`
+    - `Comprobante33` uses `CFDI33`
+    - `Comprobante32` uses `CFDI32`
+    - `Retenciones10` uses `RET10`
+- Rename `ExpressionExtractor` to `DiscoverExtractor`, it makes more sense
 
 
 ## Version 1.0.0 2019-03-27

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -1,0 +1,42 @@
+# SEMVER
+
+Respetamos el estándar [Versionado Semántico 2.0.0](https://semver.org/lang/es/).
+
+En resumen, [SemVer](https://semver.org/) es un sistema de versiones de tres componentes `X.Y.Z`
+que nombraremos así: ` Breaking . Feature . Fix `, donde:
+
+- `Breaking`: Rompe la compatibilidad de código con versiones anteriores.
+- `Feature`: Agrega una nueva característica que es compatible con lo anterior.
+- `Fix`: Incluye algún cambio (generalmente correcciones) que no agregan nueva funcionalidad.
+
+## Composer
+
+[Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
+Este gestor usa las [reglas](https://getcomposer.org/doc/articles/versions.md)
+de versionado semántico para instalar y actualizar paquetes.
+
+Te recomendamos instalar dependencias de librerías (no frameworks) con *Caret Version Range*.
+Por ejemplo: `"vendor/package": "^2.5"`.
+
+Esto significa que:
+
+- no debe actualizar a versiones `3.x.x`
+- no debe utilizar ninguna versión menor a `2.5.0`
+
+## Versiones 0.x.y no rompe compatibilidad
+
+Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reglas de versionado.
+Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto
+introducen cambios sin previo aviso.
+
+## `@internal` no rompe compatibilidad
+
+Si la librería contiene elementos marcados como `@internal` significa que no deben ser utilizados
+por tu código. Son partes de código internos de la librería.
+Por lo tanto, no se consideran breaking changes.
+
+Cuando un elemento es `@internal`, dicho elemento:
+
+- no debe ser una entrada (parámetro)
+- no debe ser una salida (retorno)
+- no debe exponer exponer funcionalidades en los objetos públicos (rasgos)

--- a/src/ExpressionExtractorInterface.php
+++ b/src/ExpressionExtractorInterface.php
@@ -8,7 +8,17 @@ use DOMDocument;
 
 interface ExpressionExtractorInterface
 {
+    public function uniqueName(): string;
+
     public function matches(DOMDocument $document): bool;
 
     public function extract(DOMDocument $document): string;
+
+    /**
+     * Format an expression based on given values
+     *
+     * @param array<string, string> $values
+     * @return string
+     */
+    public function format(array $values): string;
 }

--- a/src/Extractors/Comprobante32.php
+++ b/src/Extractors/Comprobante32.php
@@ -20,6 +20,11 @@ class Comprobante32 implements ExpressionExtractorInterface
         $this->matchDetector = new MatchDetector('http://www.sat.gob.mx/cfd/3', 'cfdi:Comprobante', 'version', '3.2');
     }
 
+    public function uniqueName(): string
+    {
+        return 'CFDI32';
+    }
+
     public function matches(DOMDocument $document): bool
     {
         return $this->matchDetector->matches($document);
@@ -35,14 +40,25 @@ class Comprobante32 implements ExpressionExtractorInterface
         $uuid = $helper->getAttribute('cfdi:Comprobante', 'cfdi:Complemento', 'tfd:TimbreFiscalDigital', 'UUID');
         $rfcEmisor = $helper->getAttribute('cfdi:Comprobante', 'cfdi:Emisor', 'rfc');
         $rfcReceptor = $helper->getAttribute('cfdi:Comprobante', 'cfdi:Receptor', 'rfc');
-        $totalComprobante = $helper->getAttribute('cfdi:Comprobante', 'total');
+        $total = $helper->getAttribute('cfdi:Comprobante', 'total');
 
-        return '?' . implode('&', [
-            're=' . $rfcEmisor,
-            'rr=' . $rfcReceptor,
-            'tt=' . $this->formatTotal($totalComprobante),
-            'id=' . $uuid,
+        return $this->format([
+            're' => $rfcEmisor,
+            'rr' => $rfcReceptor,
+            'tt' => $total,
+            'id' => $uuid,
         ]);
+    }
+
+    public function format(array $values): string
+    {
+        return '?'
+            . implode('&', [
+                're=' . ($values['re'] ?? ''),
+                'rr=' . ($values['rr'] ?? ''),
+                'tt=' . $this->formatTotal($values['tt'] ?? ''),
+                'id=' . ($values['id'] ?? ''),
+            ]);
     }
 
     public function formatTotal(string $input): string

--- a/src/Extractors/Comprobante33.php
+++ b/src/Extractors/Comprobante33.php
@@ -20,6 +20,11 @@ class Comprobante33 implements ExpressionExtractorInterface
         $this->matchDetector = new MatchDetector('http://www.sat.gob.mx/cfd/3', 'cfdi:Comprobante', 'Version', '3.3');
     }
 
+    public function uniqueName(): string
+    {
+        return 'CFDI33';
+    }
+
     public function matches(DOMDocument $document): bool
     {
         return $this->matchDetector->matches($document);
@@ -35,18 +40,28 @@ class Comprobante33 implements ExpressionExtractorInterface
         $uuid = $helper->getAttribute('cfdi:Comprobante', 'cfdi:Complemento', 'tfd:TimbreFiscalDigital', 'UUID');
         $rfcEmisor = $helper->getAttribute('cfdi:Comprobante', 'cfdi:Emisor', 'Rfc');
         $rfcReceptor = $helper->getAttribute('cfdi:Comprobante', 'cfdi:Receptor', 'Rfc');
-        $totalComprobante = $helper->getAttribute('cfdi:Comprobante', 'Total');
+        $total = $helper->getAttribute('cfdi:Comprobante', 'Total');
         $sello = substr($helper->getAttribute('cfdi:Comprobante', 'Sello'), -8);
 
-        $total = $this->formatTotal($totalComprobante);
-
-        return 'https://verificacfdi.facturaelectronica.sat.gob.mx/default.aspx?' . implode('&', [
-            'id=' . $uuid,
-            're=' . $rfcEmisor,
-            'rr=' . $rfcReceptor,
-            'tt=' . $total,
-            'fe=' . substr($sello, -8),
+        return $this->format([
+            'id' => $uuid,
+            're' => $rfcEmisor,
+            'rr' => $rfcReceptor,
+            'tt' => $total,
+            'fe' => substr($sello, -8),
         ]);
+    }
+
+    public function format(array $values): string
+    {
+        return 'https://verificacfdi.facturaelectronica.sat.gob.mx/default.aspx?'
+            . implode('&', [
+                'id=' . ($values['id'] ?? ''),
+                're=' . ($values['re'] ?? ''),
+                'rr=' . ($values['rr'] ?? ''),
+                'tt=' . $this->formatTotal($values['tt'] ?? ''),
+                'fe=' . ($values['fe'] ?? ''),
+            ]);
     }
 
     public function formatTotal(string $input): string

--- a/src/Extractors/Retenciones10.php
+++ b/src/Extractors/Retenciones10.php
@@ -26,6 +26,11 @@ class Retenciones10 implements ExpressionExtractorInterface
         );
     }
 
+    public function uniqueName(): string
+    {
+        return 'RET10';
+    }
+
     public function matches(DOMDocument $document): bool
     {
         return $this->matchDetector->matches($document);
@@ -76,12 +81,33 @@ class Retenciones10 implements ExpressionExtractorInterface
             $helper->getAttribute('retenciones:Retenciones', 'retenciones:Totales', 'montoTotOperacion')
         );
 
-        return '?' . implode('&', array_filter([
-            're=' . $rfcEmisor,
-            $rfcReceptorKey . '=' . $rfcReceptor,
-            'tt=' . $this->formatTotal($total),
-            'id=' . $uuid,
-        ]));
+        return $this->format([
+            're' => $rfcEmisor,
+            $rfcReceptorKey => $rfcReceptor,
+            'tt' => $this->formatTotal($total),
+            'id' => $uuid,
+        ]);
+    }
+
+    public function format(array $values): string
+    {
+        $receptorKey = 'rr';
+        if (isset($values['nr'])) {
+            $receptorKey = 'nr';
+            $values['nr'] = $this->formatForeignTaxId($values['nr']);
+        }
+        return '?'
+            . implode('&', [
+                're=' . ($values['re'] ?? ''),
+                $receptorKey . '=' . ($values[$receptorKey] ?? ''),
+                'tt=' . $this->formatTotal($values['tt'] ?? ''),
+                'id=' . ($values['id'] ?? ''),
+            ]);
+    }
+
+    public function formatForeignTaxId(string $foreignTaxId): string
+    {
+        return str_pad($foreignTaxId, 20, '0', STR_PAD_LEFT);
     }
 
     public function formatTotal(string $input): string

--- a/tests/Unit/DiscoverExtractorTest.php
+++ b/tests/Unit/DiscoverExtractorTest.php
@@ -5,15 +5,21 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiExpresiones\Tests\Unit;
 
 use DOMDocument;
+use PhpCfdi\CfdiExpresiones\DiscoverExtractor;
 use PhpCfdi\CfdiExpresiones\Exceptions\UnmatchedDocumentException;
-use PhpCfdi\CfdiExpresiones\ExpressionExtractor;
 use PhpCfdi\CfdiExpresiones\ExpressionExtractorInterface;
 
-class GenericExtractorTest extends DOMDocumentsTestCase
+class DiscoverExtractorTest extends DOMDocumentsTestCase
 {
+    public function testUniqueName(): void
+    {
+        $extrator = new DiscoverExtractor();
+        $this->assertSame('discover', $extrator->uniqueName());
+    }
+
     public function testGenericExtratorUsesDefaults(): void
     {
-        $extrator = new ExpressionExtractor();
+        $extrator = new DiscoverExtractor();
         $currentExpressionExtractors = $extrator->currentExpressionExtractors();
         $this->assertCount(3, $currentExpressionExtractors);
         $this->assertContainsOnlyInstancesOf(ExpressionExtractorInterface::class, $currentExpressionExtractors);
@@ -22,16 +28,16 @@ class GenericExtractorTest extends DOMDocumentsTestCase
     public function testDontMatchUsingEmptyDocument(): void
     {
         $document = new DOMDocument();
-        $extrator = new ExpressionExtractor();
+        $extrator = new DiscoverExtractor();
         $this->assertFalse($extrator->matches($document));
     }
 
     public function testThrowExceptionOnUnmatchedDocument(): void
     {
         $document = new DOMDocument();
-        $extrator = new ExpressionExtractor();
+        $extrator = new DiscoverExtractor();
         $this->expectException(UnmatchedDocumentException::class);
-        $this->expectExceptionMessage('Cannot discover any ExpressionExtractor that matches with document');
+        $this->expectExceptionMessage('Cannot discover any DiscoverExtractor that matches with document');
         $extrator->extract($document);
     }
 
@@ -51,8 +57,22 @@ class GenericExtractorTest extends DOMDocumentsTestCase
      */
     public function testExpressionOnValidDocuments(DOMDocument $document): void
     {
-        $extrator = new ExpressionExtractor();
+        $extrator = new DiscoverExtractor();
         $this->assertTrue($extrator->matches($document));
         $this->assertNotEmpty($extrator->extract($document));
+    }
+
+    public function testFormatUsingNoType(): void
+    {
+        $extrator = new DiscoverExtractor();
+        $this->expectException(UnmatchedDocumentException::class);
+        $this->expectExceptionMessage('DiscoverExtractor requires type key with an extractor identifier');
+        $extrator->format([]);
+    }
+
+    public function testFormatUsingCfdi33(): void
+    {
+        $extrator = new DiscoverExtractor();
+        $this->assertNotEmpty($extrator->format([], 'CFDI33'));
     }
 }

--- a/tests/Unit/Extractors/Comprobante32Test.php
+++ b/tests/Unit/Extractors/Comprobante32Test.php
@@ -10,6 +10,12 @@ use PhpCfdi\CfdiExpresiones\Tests\Unit\DOMDocumentsTestCase;
 
 class Comprobante32Test extends DOMDocumentsTestCase
 {
+    public function testUniqueName(): void
+    {
+        $extrator = new Comprobante32();
+        $this->assertSame('CFDI32', $extrator->uniqueName());
+    }
+
     public function testMatchesCfdi32(): void
     {
         $document = $this->documentCfdi32();

--- a/tests/Unit/Extractors/Comprobante33Test.php
+++ b/tests/Unit/Extractors/Comprobante33Test.php
@@ -10,6 +10,12 @@ use PhpCfdi\CfdiExpresiones\Tests\Unit\DOMDocumentsTestCase;
 
 class Comprobante33Test extends DOMDocumentsTestCase
 {
+    public function testUniqueName(): void
+    {
+        $extrator = new Comprobante33();
+        $this->assertSame('CFDI33', $extrator->uniqueName());
+    }
+
     public function testMatchesCfdi33(): void
     {
         $document = $this->documentCfdi33();

--- a/tests/Unit/Extractors/Retenciones10Test.php
+++ b/tests/Unit/Extractors/Retenciones10Test.php
@@ -12,6 +12,12 @@ use PhpCfdi\CfdiExpresiones\Tests\Unit\DOMDocumentsTestCase;
 
 class Retenciones10Test extends DOMDocumentsTestCase
 {
+    public function testUniqueName(): void
+    {
+        $extrator = new Retenciones10();
+        $this->assertSame('RET10', $extrator->uniqueName());
+    }
+
     public function testMatchesRetenciones10(): void
     {
         $document = $this->documentRet10Foreign();


### PR DESCRIPTION
- Allows to create an expression with format fixes from specific types
- Change `ExpressionExtractorInterface` to add `public function format(array $values): string`
- Give a unique name for extractors, so when discovering by type can obtain an item
- Change `ExpressionExtractorInterface` to add `public function uniqueName(): string`
    - `Comprobante33` uses `CFDI33`
    - `Comprobante32` uses `CFDI32`
    - `Retenciones10` uses `RET10`
- Rename `ExpressionExtractor` to `DiscoverExtractor`, it makes more sense
