### PR TITLE
Library maintenance

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -4,6 +4,11 @@ filter:
     - 'vendor/'
 
 build:
+  dependencies:
+    override:
+      - composer self-update --no-interaction --no-progress
+      - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
+      - composer install --no-interaction
   nodes:
     analysis:
       tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,7 @@
 language: php
 
 # php compatibility
-php:
-  - "7.2"
-  - "7.3"
-  - "7.4snapshot"
-
-matrix:
-  allow_failures:
-    - php: "7.4snapshot"
-
-env:
-  global:
-    - PHP_CS_FIXER_FUTURE_MODE=1
-    - PHP_CS_FIXER_IGNORE_ENV=1
+php: ["7.2", "7.3", "7.4"]
 
 cache:
   - directories:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 PHPCFDI
+Copyright (c) 2019 - 2020 PHPCFDI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ $document->load('archivo-cfdi.xml');
 
 // obtenemos la expresión
 $expression = $extractor->extract($document);
+
+// y también podemos obtener los valores inviduales
+$values = $extractor->obtain($document);
 ```
 
 ## Compatilibilidad

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [source]: https://github.com/phpcfdi/cfdi-expresiones
 [release]: https://github.com/phpcfdi/cfdi-expresiones/releases
 [license]: https://github.com/phpcfdi/cfdi-expresiones/blob/master/LICENSE
-[build]: https://travis-ci.org/phpcfdi/cfdi-expresiones?branch=master
+[build]: https://travis-ci.com/phpcfdi/cfdi-expresiones?branch=master
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/cfdi-expresiones/
 [coverage]: https://scrutinizer-ci.com/g/phpcfdi/cfdi-expresiones/code-structure/master/code-coverage
 [downloads]: https://packagist.org/packages/phpcfdi/cfdi-expresiones
@@ -103,7 +103,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/cfdi--expresiones-blue.svg?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/cfdi-expresiones.svg?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/cfdi-expresiones.svg?style=flat-square
-[badge-build]: https://img.shields.io/travis/phpcfdi/cfdi-expresiones/master.svg?style=flat-square
+[badge-build]: https://img.shields.io/travis/com/phpcfdi/cfdi-expresiones/master.svg?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/cfdi-expresiones/master.svg?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/cfdi-expresiones/master.svg?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/phpcfdi/cfdi-expresiones.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $expression = $extractor->extract($document);
 ## Compatilibilidad
 
 Esta librería se mantendrá compatible con al menos la versión con
-[soporte activo de PHP](http://php.net/supported-versions.php) más reciente.
+[soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.
 
 También utilizamos [Versionado Semántico 2.0.0](https://semver.org/lang/es/) por lo que puedes usar esta librería
 sin temor a romper tu aplicación.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^8.4",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan": "^0.11"
+        "phpstan/phpstan": "^0.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-dom": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.4",
+        "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
         "phpstan/phpstan": "^0.12"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpunit/phpunit": "^8.4",
         "squizlabs/php_codesniffer": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "phpstan/phpstan-shim": "^0.11"
+        "phpstan/phpstan": "^0.11"
     },
     "autoload": {
         "psr-4": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Notice: This library follows [SEMVER 2.0.0](https://semver.org/spec/v2.0.0.html) convention.
 
+## Version 3.0.1 2020-01-24
+
+This is a maintenance release.
+
+- Add example for `obtain` method.
+- Upgrade from `phpstan/phpstan-shim: ^0.11` to `phpstan/phpstan-shim: ^0.12`.
+- Update license year to 2020.
+- Fix links on README.
+- Update Travis-CI and Scrutinizer-CI scripts.
+
 ## Version 3.0.0 2019-10-24
 
 You should not have any trouble upgrading to from version `2.0.0` to `3.0.0` unless you are creating a concrete

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
          bootstrap="./tests/bootstrap.php" colors="true" verbose="true" cacheResultFile="build/phpunit.result.cache">
     <testsuites>
         <testsuite name="Default">

--- a/src/ExpressionExtractorInterface.php
+++ b/src/ExpressionExtractorInterface.php
@@ -27,7 +27,7 @@ interface ExpressionExtractorInterface
      * Obtain the relevant values from the given XML Document
      *
      * @param DOMDocument $document
-     * @return array
+     * @return array<string, string>
      */
     public function obtain(DOMDocument $document): array;
 

--- a/tests/Unit/DiscoverExtractorTest.php
+++ b/tests/Unit/DiscoverExtractorTest.php
@@ -41,7 +41,8 @@ class DiscoverExtractorTest extends DOMDocumentsTestCase
         $extrator->extract($document);
     }
 
-    public function providerExpressionOnValidDocuments()
+    /** @return array<string, array> */
+    public function providerExpressionOnValidDocuments(): array
     {
         return [
             'Cfdi33' => [$this->documentCfdi33(), 'CFDI33'],


### PR DESCRIPTION
- Add example for `obtain` method.
- Upgrade from `phpstan/phpstan-shim: ^0.11` to `phpstan/phpstan-shim: ^0.12`.
- Update license year to 2020.
- Fix links on README.
- Update Travis-CI and Scrutinizer-CI scripts.
