### PR TITLE
Actualización de proyecto 2021-01-11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
-/vendor              export-ignore
+/vendor/             export-ignore
 /composer.lock       export-ignore
 
 # Do not put this files on a distribution package

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
     ->setRules([
         '@PSR2' => true,
         '@PHP70Migration' => true,
         '@PHP70Migration:risky' => true,
         '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
+        // '@PHP73Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,11 +6,13 @@ filter:
 build:
   dependencies:
     override:
-      - composer self-update --no-interaction --no-progress
+      - composer self-update --2 --stable --no-interaction --no-progress
       - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer phpstan/phpstan --dev --no-interaction --no-progress --no-update
-      - composer install --no-interaction
+      - composer update --no-interaction --no-progress
   nodes:
     analysis:
+      project_setup:
+        override: true
       tests:
         override:
           - php-scrutinizer-run --enable-security-analysis

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ script:
   - vendor/bin/phpstan analyse --no-progress --level max src/ tests/
 
 notifications:
-  email: false
+  email:
+    if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ env:
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer self-update --2 --stable --no-interaction --no-progress
+  - travis_retry composer upgrade --prefer-dist --no-interaction --no-progress
 
 script:
   - vendor/bin/php-cs-fixer fix --dry-run --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ before_script:
 
 script:
   - vendor/bin/php-cs-fixer fix --dry-run --verbose
-  - vendor/bin/phpcbf --colors -sp src/ tests/
+  - vendor/bin/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit --testdox --verbose
-  - vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/
+  - vendor/bin/phpstan analyse --no-progress --level max src/ tests/
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
 
 # php compatibility
-php: ["7.2", "7.3", "7.4"]
+php: ["7.2", "7.3", "7.4", "8.0"]
 
 cache:
   - directories:
     - $HOME/.composer
+
+env:
+  global:
+    - PHP_CS_FIXER_IGNORE_ENV=yes
 
 before_script:
   - phpenv config-rm xdebug.ini || true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,74 +1,78 @@
-# Contributor Covenant Code of Conduct
 
-## Our Pledge
+# Código de Conducta convenido para Contribuyentes
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+## Nuestro compromiso
 
-## Our Standards
+Nosotros, como miembros, contribuyentes y administradores nos comprometemos a hacer de la participación en nuestra comunidad una experiencia libre de acoso para todo el mundo, independientemente de la edad, dimensión corporal, minusvalía visible o invisible, etnicidad, características sexuales, identidad y expresión de género, nivel de experiencia, educación, nivel socioeconómico, nacionalidad, apariencia personal, raza, religión, o identidad u orientación sexual.
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Nos comprometemos a actuar e interactuar de maneras que contribuyan a una comunidad abierta, acogedora, diversa, inclusiva y sana.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+## Nuestros estándares
 
-Examples of unacceptable behavior by participants include:
+Ejemplos de comportamiento que contribuyen a crear un ambiente positivo para nuestra comunidad:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* Demostrar empatía y amabilidad ante otras personas
+* Respeto a diferentes opiniones, puntos de vista y experiencias
+* Dar y aceptar adecuadamente retroalimentación constructiva
+* Aceptar la responsabilidad y disculparse ante quienes se vean afectados por nuestros errores, aprendiendo de la experiencia
+* Centrarse en lo que sea mejor no solo para nosotros como individuos, sino para la comunidad en general
 
-## Our Responsibilities
+Ejemplos de comportamiento inaceptable:
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+* El uso de lenguaje o imágenes sexualizadas, y aproximaciones o atenciones sexuales de cualquier tipo
+* Comentarios despectivos (_trolling_), insultantes o derogatorios, y ataques personales o políticos
+* El acoso en público o privado
+* Publicar información privada de otras personas, tales como direcciones físicas o de correo electrónico, sin su permiso explícito
+* Otras conductas que puedan ser razonablemente consideradas como inapropiadas en un entorno profesional
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+## Aplicación de las responsabilidades
 
-## Scope
+Los administradores de la comunidad son responsables de aclarar y hacer cumplir nuestros estándares de comportamiento aceptable y tomarán acciones apropiadas y correctivas de forma justa en respuesta a cualquier comportamiento que consideren inapropiado, amenazante, ofensivo o dañino.
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+Los administradores de la comunidad tendrán el derecho y la responsabilidad de eliminar, editar o rechazar comentarios, _commits_, código, ediciones de páginas de wiki, _issues_ y otras contribuciones que no se alineen con este Código de Conducta, y comunicarán las razones para sus decisiones de moderación cuando sea apropiado.
 
-## Enforcement
+## Alcance
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at eclipxe13@gmail.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+Este código de conducta aplica tanto a espacios del proyecto como a espacios públicos donde un individuo esté en representación del proyecto o comunidad. Ejemplos de esto incluyen el uso de la cuenta oficial de correo electrónico, publicaciones a través de las redes sociales oficiales, o presentaciones con personas designadas en eventos en línea o no.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+## Aplicación
 
-## Attribution
+Instancias de comportamiento abusivo, acosador o inaceptable de otro modo podrán ser reportadas a los administradores de la comunidad responsables del cumplimiento a través de [coc@phpcfdi.com](). Todas las quejas serán evaluadas e investigadas de una manera puntual y justa.
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+Todos los administradores de la comunidad están obligados a respetar la privacidad y la seguridad de quienes reporten incidentes.
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+## Guías de Aplicación
+
+Los administradores de la comunidad seguirán estas Guías de Impacto en la Comunidad para determinar las consecuencias de cualquier acción que juzguen como un incumplimiento de este Código de Conducta:
+
+### 1. Corrección
+
+**Impacto en la Comunidad**: El uso de lenguaje inapropiado u otro comportamiento considerado no profesional o no acogedor en la comunidad.
+
+**Consecuencia**: Un aviso escrito y privado por parte de los administradores de la comunidad, proporcionando claridad alrededor de la naturaleza de este incumplimiento y una explicación de por qué el comportamiento es inaceptable. Una disculpa pública podría ser solicitada.
+
+### 2. Aviso
+
+**Impacto en la Comunidad**: Un incumplimiento causado por un único incidente o por una cadena de acciones.
+
+**Consecuencia**: Un aviso con consecuencias por comportamiento prolongado. No se interactúa con las personas involucradas, incluyendo interacción no solicitada con quienes se encuentran aplicando el Código de Conducta, por un periodo especificado de tiempo. Esto incluye evitar las interacciones en espacios de la comunidad, así como a través de canales externos como las redes sociales. Incumplir estos términos puede conducir a una expulsión temporal o permanente.
+
+### 3. Expulsión temporal
+
+**Impacto en la Comunidad**: Una serie de incumplimientos de los estándares de la comunidad, incluyendo comportamiento inapropiado continuo.
+
+**Consecuencia**: Una expulsión temporal de cualquier forma de interacción o comunicación pública con la comunidad durante un intervalo de tiempo especificado. No se permite interactuar de manera pública o privada con las personas involucradas, incluyendo interacciones no solicitadas con quienes se encuentran aplicando el Código de Conducta, durante este periodo. Incumplir estos términos puede conducir a una expulsión permanente.
+
+### 4. Expulsión permanente
+
+**Impacto en la Comunidad**: Demostrar un patrón sistemático de incumplimientos de los estándares de la comunidad, incluyendo conductas inapropiadas prolongadas en el tiempo, acoso de individuos, o agresiones o menosprecio a grupos de individuos.
+
+**Consecuencia**: Una expulsión permanente de cualquier tipo de interacción pública con la comunidad del proyecto.
+
+## Atribución
+
+Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 2.0, disponible en <https://www.contributor-covenant.org/es/version/2/0/code_of_conduct.html>.
+
+Las Guías de Impacto en la Comunidad están inspiradas en la [escalera de aplicación del código de conducta de Mozilla](https://github.com/mozilla/diversity).
+
+Para respuestas a las preguntas frecuentes de este código de conducta, consulta las FAQ en <https://www.contributor-covenant.org/faq>. Hay traducciones disponibles en <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,85 @@
-# Contributing
+# Contribuciones
 
-Contributions are welcome. We accept pull requests on [GitHub](https://github.com/phpcfdi/cfdi-expresiones).
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][homepage].
 
-This project adheres to a
-[Contributor Code of Conduct](https://github.com/phpcfdi/cfdi-expresiones/blob/master/CODE_OF_CONDUCT.md).
-By participating in this project and its community, you are expected to uphold this code.
+Este proyecto se apega al siguiente [Código de Conducta][coc].
+Al participar en este proyecto y en su comunidad, deberás seguir este código.
 
-## Team members
+## Miembros del equipo
 
-* [Carlos C Soto](https://github.com/eclipxe13) - original author and maintainer
-* [GitHub contributors](https://github.com/phpcfdi/cfdi-expresiones/graphs/contributors)
+* [phpCfdi][] - Organización que mantiene el proyecto.
+* [Contribuidores][contributors].
 
-## Communication Channels
+## Canales de comunicación
 
-You can find help and discussion in the following places:
+Puedes encontrar ayuda y comentar asuntos relacionados con este proyecto en estos lugares:
 
+* Comunidad Discord: <https://discord.gg/aFGYXvX>
 * GitHub Issues: <https://github.com/phpcfdi/cfdi-expresiones/issues>
 
-## Reporting Bugs
+## Reportar Bugs
 
-Bugs are tracked in our project's [issue tracker](https://github.com/phpcfdi/cfdi-expresiones/issues).
+Publica los *Bugs* en la sección [GitHub Issues][issues] del proyecto.
 
-When submitting a bug report, please include enough information for us to reproduce the bug.
-A good bug report includes the following sections:
+Sigue las recomendaciones generales de [phpCfdi][] para reportar problemas
+<https://www.phpcfdi.com/general/reportar-problemas/>.
 
-* Expected outcome
-* Actual outcome
-* Steps to reproduce, including sample code
-* Any other information that will help us debug and reproduce the issue, including stack traces, system/environment information, and screenshots
+Cuando se reporte un *Bug*, por favor incluye la mayor información posible para reproducir el problema, preferentemente
+con ejemplos de código o cualquier otra información técnica que nos pueda ayudar a identificar el caso.
 
-**Please do not include passwords or any personally identifiable information in your bug report and sample code.**
+**Recuerda no incluir contraseñas, información personal o confidencial.**
 
-## Fixing Bugs
+## Corrección de Bugs
 
-We welcome pull requests to fix bugs!
+Apreciamos mucho los *Pull Request* para corregir Bugs.
 
-If you see a bug report that you'd like to fix, please feel free to do so.
-Following the directions and guidelines described in the "Adding New Features"
-section below, you may create bugfix branches and send us pull requests.
+Si encuentras un reporte de Bug y te gustaría solucionarlo siéntete libre de hacerlo.
+Sigue las directrices de "Agregar nuevas funcionalidades" a continuación.
 
-## Adding New Features
+## Agregar nuevas funcionalidades
 
-If you have an idea for a new feature, it's a good idea to check out our
-[issues](https://github.com/phpcfdi/cfdi-expresiones/issues) or active
-[pull requests](https://github.com/phpcfdi/cfdi-expresiones/pulls)
-first to see if the feature is already being worked on.
-If not, feel free to submit an issue first, asking whether the feature is beneficial to the project.
-This will save you from doing a lot of development work only to have your feature rejected.
-We don't enjoy rejecting your hard work, but some features just don't fit with the goals of the project.
+Si tienes una idea para una nueva funcionalidad revisa primero que existan discusiones o *Pull Requests*
+en donde ya se esté trabajando en la funcionalidad.
 
-When you do begin working on your feature, here are some guidelines to consider:
+Antes de trabajar en la nueva característica, utiliza los "Canales de comunicación" mencionados
+anteriormente para platicar acerca de tu idea. Si dialogas tus ideas con la comunidad y los
+mantenedores del proyecto, podrás ahorrar mucho esfuerzo de desarrollo y prevenir que tu
+*Pull Request* sea rechazado. No nos gusta rechazar contribuciones, pero algunas características
+o la forma de desarrollarlas puede que no estén alineadas con el proyecto.
 
-* Your pull request description should clearly detail the changes you have made.
-* Follow our code style using `squizlabs/php_codesniffer` and `friendsofphp/php-cs-fixer`.
-* Please **write tests** for any new features you add.
-* Please **ensure that tests pass** before submitting your pull request. We have Travis CI automatically running tests for pull requests. However, running the tests locally will help save time.
-* **Use topic/feature branches.** Please do not ask us to pull from your master branch.
-* **Submit one feature per pull request.** If you have multiple features you wish to submit, please break them up into separate pull requests.
-* **Send coherent history**. Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+Considera las siguientes directrices:
 
-## Check the code style
+* Usa una rama única que se desprenda de la rama principal.
+  No mezcles dos diferentes funcionalidades en una misma rama o *Pull Request*.
+* Describe claramente y en detalle los cambios que hiciste.
+* **Escribe pruebas** para la funcionalidad que deseas agregar.
+* **Asegúrate que las pruebas pasan** antes de enviar tu contribución.
+  Usamos integración contínua donde se hace esta verificación, pero es mucho mejor si lo pruebas localmente.
+* Intenta enviar una historia coherente, entenderemos cómo cambia el código si los *commits* tienen significado.
+* La documentación es parte del proyecto.
+  Realiza los cambios en los archivos de ayuda para que reflejen los cambios en el código.
 
-If you are having issues with coding standars use `php-cs-fixer` and `phpcbf`
+## Proceso de construcción
 
 ```shell
-vendor/bin/php-cs-fixer fix -v
-vendor/bin/phpcbf src/ tests/
+# Actualiza tus dependencias
+composer update
+
+# Verificación de estilo de código
+composer dev:check-style
+
+# Corrección de estilo de código
+composer dev:fix-style
+
+# Ejecución de pruebas
+composer dev:test
+
+# Ejecución todo en uno, corregir estilo, verificar estilo y correr pruebas
+composer dev:build
 ```
 
-## Running Tests
-
-The following tests must pass before we will accept a pull request.
-If any of these do not pass, it will result in a complete build failure.
-Before you can run these, be sure to `composer install` or `composer update`.
-
-```shell
-vendor/bin/phpcs -sp src/ tests/
-vendor/bin/php-cs-fixer fix -v --dry-run
-vendor/bin/phpunit --coverage-text
-vendor/bin/phpstan analyse --level max src/ tests/
-```
+[phpCfdi]:      https://github.com/phpcfdi/
+[project]:      https://github.com/phpcfdi/cfdi-expresiones
+[contributors]: https://github.com/phpcfdi/cfdi-expresiones/graphs/contributors
+[coc]:          https://github.com/phpcfdi/cfdi-expresiones/blob/master/CODE_OF_CONDUCT.md
+[issues]:       https://github.com/phpcfdi/cfdi-expresiones/issues

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2020 PHPCFDI
+Copyright (c) 2019 - 2021 PHPCFDI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $values = $extractor->obtain($document);
 Esta librería se mantendrá compatible con al menos la versión con
 [soporte activo de PHP](https://www.php.net/supported-versions.php) más reciente.
 
-También utilizamos [Versionado Semántico 2.0.0](https://semver.org/lang/es/) por lo que puedes usar esta librería
+También utilizamos [Versionado Semántico 2.0.0](docs/SEMVER.md) por lo que puedes usar esta librería
 sin temor a romper tu aplicación.
 
 ### Cambiar de la versión 2.0.0 a la versión 3.0.0
@@ -84,11 +84,11 @@ versión mayor. Puedes actualizar con confianza si no creaste alguna clase que i
 ## Contribuciones
 
 Las contribuciones con bienvenidas. Por favor lee [CONTRIBUTING][] para más detalles
-y recuerda revisar el archivo de tareas pendientes [TODO][] y el [CHANGELOG][].
+y recuerda revisar el archivo de tareas pendientes [TODO][] y el archivo [CHANGELOG][].
 
 ## Copyright and License
 
-The phpcfdi/cfdi-expresiones library is copyright © [PhpCfdi](https://www.phpcfdi.com/)
+The `phpcfdi/cfdi-expresiones` library is copyright © [PhpCfdi](https://www.phpcfdi.com/)
 and licensed for use under the MIT License (MIT). Please see [LICENSE][] for more information.
 
 [contributing]: https://github.com/phpcfdi/cfdi-expresiones/blob/master/CONTRIBUTING.md

--- a/composer.json
+++ b/composer.json
@@ -45,20 +45,20 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
-            "vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "vendor/bin/phpcs --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
+            "@php vendor/bin/phpcs --colors -sp src/ tests/"
         ],
         "dev:fix-style": [
-            "vendor/bin/php-cs-fixer fix --verbose",
-            "vendor/bin/phpcbf --colors -sp src/ tests/"
+            "@php vendor/bin/php-cs-fixer fix --verbose",
+            "@php vendor/bin/phpcbf --colors -sp src/ tests/"
         ],
         "dev:test": [
             "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
-            "vendor/bin/phpstan analyse --verbose --no-progress --level max src/ tests/"
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpstan analyse --no-progress --verbose --level max src/ tests/"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --testdox --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ This is a maintenance release.
 - Add example for `obtain` method.
 - Upgrade from `phpstan/phpstan-shim: ^0.11` to `phpstan/phpstan-shim: ^0.12`.
 - Update license year to 2020.
-- Fix links on README.
+- Fix links on README file.
 - Update Travis-CI and Scrutinizer-CI scripts.
 
 ## Version 3.0.0 2019-10-24
@@ -25,7 +25,7 @@ class that implements `ExpressionExtractorInterface`.
   that returns the extracted values, this change remove this responsability from `extract` method.
 - [BC] Change `DiscoverExtractor::format()`, second argument must be `string`, was `mixed`.
 - Update continuous integration and development environment, mayor changes:
-    - Travis build on PHP version `7.4snapshot`.
+    - Travis builds on PHP version `7.4snapshot`.
     - Scrutinizer decides which PHP version to run.
     - Remove `overtrue/phplint`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,30 @@
 # CHANGELOG
 
-Notice: This library follows [SEMVER 2.0.0](https://semver.org/spec/v2.0.0.html) convention.
+## Acerca de SemVer
 
-## UNRELEASED 2020-01-11
+Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta librería sin temor a romper tu aplicación.
 
-- Fix PHPStan issue on tests.
+## Cambios no liberados en una versión
 
-## Version 3.0.1 2020-01-24
+Pueden aparecer cambios no liberados que se integran a la rama principal pero no ameritan una nueva liberación de
+versión aunque sí su incorporación en la rama principal de trabajo, generalmente se tratan de cambios en el desarrollo.
+
+## Listado de cambios
+
+### UNRELEASED 2021-01-11
+
+Ninguno de estos cambios introducen alguna modificación en el código, solo en las pruebas y en el entorno de desarrollo.
+Por esto no se libera una nueva versión y solo se actualiza la rama principal.
+
+- Actualización del año en la licencia, feliz 2021 desde PhpCfdi.
+- Se actualiza la documentación a español.
+- Se incluye PHP 8.0 en la construcción de Travis-CI.
+- Arreglar los problemas encontrados por PHPStan.
+- Se actualizan los archivos de configuración.
+- Se actualizan los pasos de construcción en Travis-CI y Scrutinizer.
+- Composer: Se actualizan los comandos de desarrollo para que usen el comando con el que composer fue invocado.
+
+### Version 3.0.1 2020-01-24
 
 This is a maintenance release.
 
@@ -16,7 +34,7 @@ This is a maintenance release.
 - Fix links on README file.
 - Update Travis-CI and Scrutinizer-CI scripts.
 
-## Version 3.0.0 2019-10-24
+### Version 3.0.0 2019-10-24
 
 You should not have any trouble upgrading to from version `2.0.0` to `3.0.0` unless you are creating a concrete
 class that implements `ExpressionExtractorInterface`. 
@@ -29,7 +47,7 @@ class that implements `ExpressionExtractorInterface`.
     - Scrutinizer decides which PHP version to run.
     - Remove `overtrue/phplint`.
 
-## Version 2.0.0 2019-03-28
+### Version 2.0.0 2019-03-28
 
 - Allows to create an expression with format fixes from specific types
 - Change `ExpressionExtractorInterface` to add `public function format(array $values): string`
@@ -40,7 +58,7 @@ class that implements `ExpressionExtractorInterface`.
     - `Retenciones10` uses `RET10`
 - Rename `ExpressionExtractor` to `DiscoverExtractor`, it makes more sense
 
-## Version 1.0.0 2019-03-27
+### Version 1.0.0 2019-03-27
 
 - Create this package as is a common use between other packages
 - Include Retenciones e información de pagos (RET10)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Notice: This library follows [SEMVER 2.0.0](https://semver.org/spec/v2.0.0.html) convention.
 
+## UNRELEASED 2020-01-11
+
+- Fix PHPStan issue on tests.
+
 ## Version 3.0.1 2020-01-24
 
 This is a maintenance release.

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -11,7 +11,7 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 
 ## Composer
 
-[Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
+La herramienta [Composer](https://getcomposer.org/) es un gestor de dependencias en proyectos para PHP.
 Este gestor usa las [reglas](https://getcomposer.org/doc/articles/versions.md)
 de versionado semántico para instalar y actualizar paquetes.
 
@@ -39,4 +39,4 @@ Cuando un elemento es `@internal`, dicho elemento:
 
 - no debe ser una entrada (parámetro)
 - no debe ser una salida (retorno)
-- no debe exponer exponer funcionalidades en los objetos públicos (rasgos)
+- no debe exponer funcionalidades en los objetos públicos (rasgos)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,3 +1,9 @@
-# phpcfdi/cfdi-expresiones To Do List
+# phpcfdi/cfdi-expresiones Lista de tareas pendientes
 
-- 2019-10-24: Nada pendiente aún.
+## Pendientes
+
+*Describa aquí el un nivel 3 una tarea pendiente.*
+
+## Hechas
+
+*Una vez realizada la tarea muévala a esta sección.*

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,7 +5,7 @@
     <arg name="encoding" value="utf-8"/>
     <arg name="report-width" value="auto"/>
     <arg name="extensions" value="php"/>
-    <rule ref="PSR2" />
+    <rule ref="PSR2"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
     <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,21 @@
+<?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php" colors="true" verbose="true" cacheResultFile="build/phpunit.result.cache">
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    cacheResultFile="build/phpunit.result.cache"
+    colors="true"
+    verbose="true"
+    bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="Default">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <!-- exclude composer vendor folder -->
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>
+            <exclude>
+                <directory suffix=".php">./src/ComplianceTester</directory>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Internal/DOMHelper.php
+++ b/src/Internal/DOMHelper.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\CfdiExpresiones\Internal;
 
 use DOMDocument;
 use DOMElement;
+use LogicException;
 use PhpCfdi\CfdiExpresiones\Exceptions\AttributeNotFoundException;
 use PhpCfdi\CfdiExpresiones\Exceptions\ElementNotFoundException;
 
@@ -26,7 +27,7 @@ class DOMHelper
     public function rootElement(): DOMElement
     {
         if (null === $this->document->documentElement) {
-            throw new \LogicException('DOMDocument does not have root element');
+            throw new LogicException('DOMDocument does not have root element');
         }
         return $this->document->documentElement;
     }

--- a/tests/Unit/Internal/DOMHelperTest.php
+++ b/tests/Unit/Internal/DOMHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiExpresiones\Tests\Unit\Internal;
 
 use DOMDocument;
+use LogicException;
 use PhpCfdi\CfdiExpresiones\Exceptions\AttributeNotFoundException;
 use PhpCfdi\CfdiExpresiones\Exceptions\ElementNotFoundException;
 use PhpCfdi\CfdiExpresiones\Internal\DOMHelper;
@@ -16,7 +17,7 @@ class DOMHelperTest extends TestCase
     {
         $document = new DOMDocument();
         $helper = new DOMHelper($document);
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $helper->rootElement();
     }
 

--- a/tests/Unit/Internal/DOMHelperTest.php
+++ b/tests/Unit/Internal/DOMHelperTest.php
@@ -69,7 +69,6 @@ class DOMHelperTest extends TestCase
         $element = $helper->findElement('b:books', 'b:library', 't:topic', 'b:book');
         if (null === $element) {
             $this->fail('Expected to exists element was not found');
-            return;
         }
         $this->assertSame('Carlos C Soto', $element->getAttribute('author'));
     }


### PR DESCRIPTION
Ninguno de estos cambios introducen alguna modificación en el código, solo en las pruebas y en el entorno de desarrollo.
Por esto no se libera una nueva versión y solo se actualiza la rama principal.

- Actualización del año en la licencia, feliz 2021 desde PhpCfdi.
- Se actualiza la documentación a español.
- Se incluye PHP 8.0 en la construcción de Travis-CI.
- Arreglar los problemas encontrados por PHPStan.
- Se actualizan los archivos de configuración.
- Se actualizan los pasos de construcción en Travis-CI y Scrutinizer.
- Composer: Se actualizan los comandos de desarrollo para que usen el comando con el que composer fue invocado.