### PR TITLE
Codificación de los caracteres especiales

### DIFF
--- a/src/Extractors/Comprobante32.php
+++ b/src/Extractors/Comprobante32.php
@@ -59,8 +59,8 @@ class Comprobante32 implements ExpressionExtractorInterface
     {
         return '?'
             . implode('&', [
-                're=' . ($values['re'] ?? ''),
-                'rr=' . ($values['rr'] ?? ''),
+                're=' . (htmlentities($values['re'] ?? '', ENT_XML1)),
+                'rr=' . (htmlentities($values['rr'] ?? '', ENT_XML1)),
                 'tt=' . $this->formatTotal($values['tt'] ?? ''),
                 'id=' . ($values['id'] ?? ''),
             ]);

--- a/src/Extractors/Comprobante33.php
+++ b/src/Extractors/Comprobante33.php
@@ -62,8 +62,8 @@ class Comprobante33 implements ExpressionExtractorInterface
         return 'https://verificacfdi.facturaelectronica.sat.gob.mx/default.aspx?'
             . implode('&', [
                 'id=' . ($values['id'] ?? ''),
-                're=' . ($values['re'] ?? ''),
-                'rr=' . ($values['rr'] ?? ''),
+                're=' . (htmlentities($values['re'] ?? '', ENT_XML1)),
+                'rr=' . (htmlentities($values['rr'] ?? '', ENT_XML1)),
                 'tt=' . $this->formatTotal($values['tt'] ?? ''),
                 'fe=' . ($values['fe'] ?? ''),
             ]);

--- a/src/Extractors/Retenciones10.php
+++ b/src/Extractors/Retenciones10.php
@@ -103,8 +103,8 @@ class Retenciones10 implements ExpressionExtractorInterface
         }
         return '?'
             . implode('&', [
-                're=' . ($values['re'] ?? ''),
-                $receptorKey . '=' . ($values[$receptorKey] ?? ''),
+                're=' . (htmlentities($values['re'] ?? '', ENT_XML1)),
+                $receptorKey . '=' . (htmlentities($values[$receptorKey] ?? '', ENT_XML1)),
                 'tt=' . $this->formatTotal($values['tt'] ?? ''),
                 'id=' . ($values['id'] ?? ''),
             ]);

--- a/tests/Unit/Extractors/Comprobante32Test.php
+++ b/tests/Unit/Extractors/Comprobante32Test.php
@@ -67,4 +67,22 @@ class Comprobante32Test extends DOMDocumentsTestCase
         $extractor = new Comprobante32();
         $this->assertSame($expectedFormat, $extractor->formatTotal($input));
     }
+
+    public function testFormatCfdi32RfcWithAmpersand(): void
+    {
+        $extractor = new Comprobante32();
+        $expected32 = implode([
+            '?re=Ñ&amp;A010101AAA',
+            '&rr=Ñ&amp;A991231AA0',
+            '&tt=0000001234.567800',
+            '&id=CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC',
+        ]);
+        $parameters = [
+            're' => 'Ñ&A010101AAA',
+            'rr' => 'Ñ&A991231AA0',
+            'tt' => '1234.5678',
+            'id' => 'CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC',
+        ];
+        $this->assertSame($expected32, $extractor->format($parameters));
+    }
 }

--- a/tests/Unit/Extractors/Comprobante33Test.php
+++ b/tests/Unit/Extractors/Comprobante33Test.php
@@ -65,4 +65,25 @@ class Comprobante33Test extends DOMDocumentsTestCase
         $extractor = new Comprobante33();
         $this->assertSame($expectedFormat, $extractor->formatTotal($input));
     }
+
+    public function testFormatCfdi33RfcWithAmpersand(): void
+    {
+        $extractor = new Comprobante33();
+        $expected33 = implode([
+            'https://verificacfdi.facturaelectronica.sat.gob.mx/default.aspx',
+            '?id=CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC',
+            '&re=Ñ&amp;A010101AAA',
+            '&rr=Ñ&amp;A991231AA0',
+            '&tt=1234.5678',
+            '&fe=23456789',
+        ]);
+        $parameters = [
+            'id' => 'CEE4BE01-ADFA-4DEB-8421-ADD60F0BEDAC',
+            're' => 'Ñ&A010101AAA',
+            'rr' => 'Ñ&A991231AA0',
+            'tt' => '1234.5678',
+            'fe' => '23456789',
+        ];
+        $this->assertSame($expected33, $extractor->format($parameters));
+    }
 }

--- a/tests/Unit/Extractors/Retenciones10Test.php
+++ b/tests/Unit/Extractors/Retenciones10Test.php
@@ -88,4 +88,22 @@ class Retenciones10Test extends DOMDocumentsTestCase
         $extractor = new Retenciones10();
         $this->assertSame($expectedFormat, $extractor->formatTotal($input));
     }
+
+    public function testFormatRetenciones10RfcWithAmpersand(): void
+    {
+        $extractor = new Retenciones10();
+        $expectedRetenciones10 = implode([
+            '?re=Ñ&amp;A010101AAA',
+            '&rr=Ñ&amp;A991231AA0',
+            '&tt=0002000000.000000',
+            '&id=fc1b47b2-42f3-4ca2-8587-36e0a216c4d5',
+        ]);
+        $parameters = [
+            're' => 'Ñ&A010101AAA',
+            'rr' => 'Ñ&A991231AA0',
+            'tt' => '2000000.00',
+            'id' => 'fc1b47b2-42f3-4ca2-8587-36e0a216c4d5',
+        ];
+        $this->assertSame($expectedRetenciones10, $extractor->format($parameters));
+    }
 }


### PR DESCRIPTION
- Se actualiza el encoding usado para los rfcs al formato de XML 1 como se reportó en el issue [https://github.com/phpcfdi/cfdi-expresiones/issues/11](url)