### PR TITLE
Mantenimiento 2024-09-09 (2)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,10 +24,6 @@ jobs:
           tools: composer:v2
         env:
           fail-fast: true
-      - name: Install poppler-utils
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt install poppler-utils
       - name: Get composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ versión, aunque sí su incorporación en la rama principal de trabajo, generalm
 - En los flujos de trabajo de integración continua:
   - Se actualizan las acciones a la versión 4.
   - Se utiliza `matrix.php-version` en lugar de `matrix.php-versions`.
+  - Se remueve la (innecesaria) instalación de `poppler-utils`.
 - Se actualizan las herramientas de desarrollo.
 
 ### Mantenimiento 2024-01-17


### PR DESCRIPTION
- En los flujos de trabajo de integración continua se remueve la (innecesaria) instalación de `poppler-utils`.