### PR TITLE
Eliminar soporte para PHP 7.3, PHP 7.4 y PHP 8.0 (versión 3.3.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,24 @@ on:
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
 
 jobs:
+
+  composer-normalize:
+    name: Composer normalization
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer-normalize
+        env:
+          fail-fast: true
+      - name: Composer normalize
+        run: composer-normalize
+
   phpcs:
     name: Code Style (phpcs)
     runs-on: "ubuntu-latest"

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -6,4 +6,5 @@
   <phar name="phpstan" version="^2.1.11" installed="2.1.11" location="./tools/phpstan" copy="false"/>
   <phar name="psalm" version="^6.10.0" installed="6.10.0" location="./tools/psalm" copy="false"/>
   <phar name="infection" version="^0.29.14" installed="0.29.14" location="./tools/infection" copy="false"/>
+  <phar name="composer-normalize" version="^2.46.0" installed="2.46.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,15 +15,16 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
+        '@PHP81Migration' => true,
+        '@PHP80Migration:risky' => true,
         // symfony
+        'array_indentation' => true,
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'type_declaration_spaces' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'parameters']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -36,6 +37,8 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
+        'global_namespace_import' => ['import_classes' => true],
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-dom": "*",
         "ext-mbstring": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-dom": "*",
         "ext-mbstring": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
     "name": "phpcfdi/cfdi-expresiones",
     "description": "Genera expresiones de CFDI 4.0, CFDI 3.3, CFDI 3.2, RET 1.0 y RET 2.0",
-    "keywords": ["phpcfdi", "sat", "cfdi"],
-    "homepage": "https://github.com/phpcfdi/cfdi-expresiones",
     "license": "MIT",
+    "keywords": [
+        "phpcfdi",
+        "sat",
+        "cfdi"
+    ],
     "authors": [
         {
             "name": "Carlos C Soto",
@@ -11,16 +14,10 @@
             "homepage": "https://eclipxe.com.mx/"
         }
     ],
+    "homepage": "https://github.com/phpcfdi/cfdi-expresiones",
     "support": {
-        "source": "https://github.com/phpcfdi/cfdi-expresiones",
-        "issues": "https://github.com/phpcfdi/cfdi-expresiones/issues"
-    },
-    "prefer-stable": true,
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": {
-            "*": "dist"
-        }
+        "issues": "https://github.com/phpcfdi/cfdi-expresiones/issues",
+        "source": "https://github.com/phpcfdi/cfdi-expresiones"
     },
     "require": {
         "php": ">=8.1",
@@ -28,9 +25,10 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "ext-json": "*"
+        "ext-json": "*",
+        "phpunit/phpunit": "^9.5"
     },
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "PhpCfdi\\CfdiExpresiones\\": "src/"
@@ -41,12 +39,24 @@
             "PhpCfdi\\CfdiExpresiones\\Tests\\": "tests/"
         }
     },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
+        }
+    },
     "scripts": {
-        "dev:build": ["@dev:fix-style", "@dev:test"],
+        "dev:build": [
+            "@dev:fix-style",
+            "@dev:test"
+        ],
         "dev:check-style": [
             "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
+        ],
+        "dev:coverage": [
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ],
         "dev:fix-style": [
             "@php tools/composer-normalize normalize",
@@ -59,16 +69,13 @@
             "@php tools/phpstan analyse --no-progress",
             "@php tools/psalm --no-progress",
             "@php tools/infection --no-progress --no-interaction --show-mutations"
-        ],
-        "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:check-style, phpunit, phpstan, psalm and infection",
-        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
+        "dev:test": "DEV: run dev:check-style, phpunit, phpstan, psalm and infection"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,12 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
+            "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
+            "@php tools/composer-normalize normalize",
             "@php tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
@@ -64,8 +66,8 @@
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
-        "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
-        "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
+        "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
         "dev:test": "DEV: run dev:check-style, phpunit, phpstan, psalm and infection",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "ext-json": "*",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^10.5.45"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-dom": "*",
         "ext-mbstring": "*"
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,16 @@ versión, aunque sí su incorporación en la rama principal de trabajo, generalm
 
 ## Listado de cambios
 
+### Version 3.3.0 2025-04-13
+
+Se elimina el soporte para PHP 7.3, PHP 7.4 y PHP 8.0.  La versión mínima es ahora PHP 8.1.
+Esto incluye cambios al código relacionados con tipos, calidad de código y eliminación de código muerto.
+
+Los siguientes cambios aplican al entorno de desarrollo.
+
+- Se agrega la herramienta `composer-normalize` al proceso de construcción.
+- Se actualiza el estándar de código para `phpcs` y `php-cs-fixer`.
+
 ### Version 3.2.1 2025-04-13
 
 - Se comprueba que el proyecto es compatible con PHP 8.4.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Esto incluye cambios al código relacionados con tipos, calidad de código y eli
 
 Los siguientes cambios aplican al entorno de desarrollo.
 
+- Se actualizan las pruebas a PHPUnit 10.
 - Se agrega la herramienta `composer-normalize` al proceso de construcción.
 - Se actualiza el estándar de código para `phpcs` y `php-cs-fixer`.
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    cacheResultFile="build/phpunit.result.cache"
-    bootstrap="tests/bootstrap.php"
-    colors="true"
-    >
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src/</directory>
-        </include>
-    </coverage>
+  xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+  cacheResultFile="build/phpunit.result.cache"
+  bootstrap="tests/bootstrap.php"
+  colors="true"
+  >
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/DiscoverExtractor.php
+++ b/src/DiscoverExtractor.php
@@ -15,7 +15,7 @@ use PhpCfdi\CfdiExpresiones\Extractors\Retenciones20;
 class DiscoverExtractor implements ExpressionExtractorInterface
 {
     /** @var ExpressionExtractorInterface[] */
-    private array $extractors;
+    private readonly array $extractors;
 
     public function __construct(ExpressionExtractorInterface ...$extractors)
     {

--- a/src/DiscoverExtractor.php
+++ b/src/DiscoverExtractor.php
@@ -15,7 +15,7 @@ use PhpCfdi\CfdiExpresiones\Extractors\Retenciones20;
 class DiscoverExtractor implements ExpressionExtractorInterface
 {
     /** @var ExpressionExtractorInterface[] */
-    private $extractors;
+    private array $extractors;
 
     public function __construct(ExpressionExtractorInterface ...$extractors)
     {

--- a/src/ExpressionExtractorInterface.php
+++ b/src/ExpressionExtractorInterface.php
@@ -10,32 +10,23 @@ interface ExpressionExtractorInterface
 {
     /**
      * Extractor (implementor) unique name
-     *
-     * @return string
      */
     public function uniqueName(): string;
 
     /**
      * Check that the XML document matches with the extractor
-     *
-     * @param DOMDocument $document
-     * @return bool
      */
     public function matches(DOMDocument $document): bool;
 
     /**
      * Obtain the relevant values from the given XML Document
      *
-     * @param DOMDocument $document
      * @return array<string, string>
      */
     public function obtain(DOMDocument $document): array;
 
     /**
      * Format an expression based on given XML document
-     *
-     * @param DOMDocument $document
-     * @return string
      */
     public function extract(DOMDocument $document): string;
 
@@ -43,7 +34,6 @@ interface ExpressionExtractorInterface
      * Format an expression based on given values
      *
      * @param array<string, string> $values
-     * @return string
      */
     public function format(array $values): string;
 }

--- a/src/Extractors/Comprobante32.php
+++ b/src/Extractors/Comprobante32.php
@@ -15,8 +15,7 @@ class Comprobante32 implements ExpressionExtractorInterface
     use Standards\FormatRfcXml;
     use Standards\FormatTotal10x6;
 
-    /** @var MatchDetector */
-    private $matchDetector;
+    private MatchDetector $matchDetector;
 
     public function __construct()
     {

--- a/src/Extractors/Retenciones10.php
+++ b/src/Extractors/Retenciones10.php
@@ -17,8 +17,7 @@ class Retenciones10 implements ExpressionExtractorInterface
     use Standards\FormatRfcXml;
     use Standards\FormatTotal10x6;
 
-    /** @var MatchDetector */
-    private $matchDetector;
+    private MatchDetector $matchDetector;
 
     public function __construct()
     {

--- a/src/Extractors/Retenciones20.php
+++ b/src/Extractors/Retenciones20.php
@@ -18,8 +18,7 @@ class Retenciones20 implements ExpressionExtractorInterface
     use Standards\FormatTotal18x6;
     use Standards\FormatSelloLast8;
 
-    /** @var MatchDetector */
-    private $matchDetector;
+    private MatchDetector $matchDetector;
 
     public function __construct()
     {

--- a/src/Extractors/Standards/Comprobante20170701.php
+++ b/src/Extractors/Standards/Comprobante20170701.php
@@ -20,11 +20,9 @@ abstract class Comprobante20170701 implements ExpressionExtractorInterface
     use FormatTotal18x6;
     use FormatSelloLast8;
 
-    /** @var MatchDetector */
-    private $matchDetector;
+    private MatchDetector $matchDetector;
 
-    /** @var string */
-    private $unmatchedExceptionMessage;
+    private string $unmatchedExceptionMessage;
 
     public function __construct(MatchDetector $matchDetector, string $unmatchedExceptionMessage)
     {

--- a/src/Extractors/Standards/Comprobante20170701.php
+++ b/src/Extractors/Standards/Comprobante20170701.php
@@ -20,14 +20,8 @@ abstract class Comprobante20170701 implements ExpressionExtractorInterface
     use FormatTotal18x6;
     use FormatSelloLast8;
 
-    private MatchDetector $matchDetector;
-
-    private string $unmatchedExceptionMessage;
-
-    public function __construct(MatchDetector $matchDetector, string $unmatchedExceptionMessage)
+    public function __construct(private MatchDetector $matchDetector, private string $unmatchedExceptionMessage)
     {
-        $this->matchDetector = $matchDetector;
-        $this->unmatchedExceptionMessage = $unmatchedExceptionMessage;
     }
 
     public function matches(DOMDocument $document): bool

--- a/src/Extractors/Standards/FormatSelloLast8.php
+++ b/src/Extractors/Standards/FormatSelloLast8.php
@@ -8,6 +8,6 @@ trait FormatSelloLast8
 {
     public function formatSello(string $sello): string
     {
-        return (string) substr($sello, -8);
+        return substr($sello, -8);
     }
 }

--- a/src/Extractors/Standards/FormatTotal18x6.php
+++ b/src/Extractors/Standards/FormatTotal18x6.php
@@ -10,7 +10,7 @@ trait FormatTotal18x6
     {
         $total = rtrim(number_format(floatval($input), 6, '.', ''), '0');
         if ('.' === substr($total, -1)) {
-            $total = $total . '0'; // add trailing zero
+            $total .= '0'; // add trailing zero
         }
         return $total;
     }

--- a/src/Extractors/Standards/FormatTotal18x6.php
+++ b/src/Extractors/Standards/FormatTotal18x6.php
@@ -9,7 +9,7 @@ trait FormatTotal18x6
     public function formatTotal(string $input): string
     {
         $total = rtrim(number_format(floatval($input), 6, '.', ''), '0');
-        if ('.' === substr($total, -1)) {
+        if (str_ends_with($total, '.')) {
             $total .= '0'; // add trailing zero
         }
         return $total;

--- a/src/Internal/DOMHelper.php
+++ b/src/Internal/DOMHelper.php
@@ -16,7 +16,7 @@ use PhpCfdi\CfdiExpresiones\Exceptions\ElementNotFoundException;
  */
 class DOMHelper
 {
-    public function __construct(private DOMDocument $document)
+    public function __construct(private readonly DOMDocument $document)
     {
     }
 

--- a/src/Internal/DOMHelper.php
+++ b/src/Internal/DOMHelper.php
@@ -16,11 +16,8 @@ use PhpCfdi\CfdiExpresiones\Exceptions\ElementNotFoundException;
  */
 class DOMHelper
 {
-    private \DOMDocument $document;
-
-    public function __construct(DOMDocument $document)
+    public function __construct(private DOMDocument $document)
     {
-        $this->document = $document;
     }
 
     public function rootElement(): DOMElement

--- a/src/Internal/DOMHelper.php
+++ b/src/Internal/DOMHelper.php
@@ -16,8 +16,7 @@ use PhpCfdi\CfdiExpresiones\Exceptions\ElementNotFoundException;
  */
 class DOMHelper
 {
-    /** @var DOMDocument */
-    private $document;
+    private \DOMDocument $document;
 
     public function __construct(DOMDocument $document)
     {

--- a/src/Internal/MatchDetector.php
+++ b/src/Internal/MatchDetector.php
@@ -53,7 +53,7 @@ class MatchDetector
     {
         try {
             $this->check($document);
-        } catch (UnmatchedDocumentException $exception) {
+        } catch (UnmatchedDocumentException) {
             return false;
         }
         return true;

--- a/tests/Unit/DOMDocumentsTestCase.php
+++ b/tests/Unit/DOMDocumentsTestCase.php
@@ -9,52 +9,52 @@ use PhpCfdi\CfdiExpresiones\Tests\TestCase;
 
 abstract class DOMDocumentsTestCase extends TestCase
 {
-    public function documentCfdi40(): DOMDocument
+    public static function documentCfdi40(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('cfdi40-real.xml'));
+        $document->load(static::filePath('cfdi40-real.xml'));
         return $document;
     }
 
-    public function documentCfdi33(): DOMDocument
+    public static function documentCfdi33(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('cfdi33-real.xml'));
+        $document->load(static::filePath('cfdi33-real.xml'));
         return $document;
     }
 
-    public function documentCfdi32(): DOMDocument
+    public static function documentCfdi32(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('cfdi32-real.xml'));
+        $document->load(static::filePath('cfdi32-real.xml'));
         return $document;
     }
 
-    public function documentRet20Mexican(): DOMDocument
+    public static function documentRet20Mexican(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('ret20-mexican-fake.xml'));
+        $document->load(static::filePath('ret20-mexican-fake.xml'));
         return $document;
     }
 
-    public function documentRet20Foreign(): DOMDocument
+    public static function documentRet20Foreign(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('ret20-foreign-fake.xml'));
+        $document->load(static::filePath('ret20-foreign-fake.xml'));
         return $document;
     }
 
-    public function documentRet10Mexican(): DOMDocument
+    public static function documentRet10Mexican(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('ret10-mexican-fake.xml'));
+        $document->load(static::filePath('ret10-mexican-fake.xml'));
         return $document;
     }
 
-    public function documentRet10Foreign(): DOMDocument
+    public static function documentRet10Foreign(): DOMDocument
     {
         $document = new DOMDocument();
-        $document->load($this->filePath('ret10-foreign-fake.xml'));
+        $document->load(static::filePath('ret10-foreign-fake.xml'));
         return $document;
     }
 }

--- a/tests/Unit/DiscoverExtractorTest.php
+++ b/tests/Unit/DiscoverExtractorTest.php
@@ -59,16 +59,16 @@ final class DiscoverExtractorTest extends DOMDocumentsTestCase
     }
 
     /** @return array<string, array{DOMDocument, string}> */
-    public function providerExpressionOnValidDocuments(): array
+    public static function providerExpressionOnValidDocuments(): array
     {
         return [
-            'Cfdi40' => [$this->documentCfdi40(), 'CFDI40'],
-            'Cfdi33' => [$this->documentCfdi33(), 'CFDI33'],
-            'Cfdi32' => [$this->documentCfdi32(), 'CFDI32'],
-            'Ret20Mexican' => [$this->documentRet20Mexican(), 'RET20'],
-            'Ret20Foreign' => [$this->documentRet20Foreign(), 'RET20'],
-            'Ret10Mexican' => [$this->documentRet10Mexican(), 'RET10'],
-            'Ret10Foreign' => [$this->documentRet10Foreign(), 'RET10'],
+            'Cfdi40' => [self::documentCfdi40(), 'CFDI40'],
+            'Cfdi33' => [self::documentCfdi33(), 'CFDI33'],
+            'Cfdi32' => [self::documentCfdi32(), 'CFDI32'],
+            'Ret20Mexican' => [self::documentRet20Mexican(), 'RET20'],
+            'Ret20Foreign' => [self::documentRet20Foreign(), 'RET20'],
+            'Ret10Mexican' => [self::documentRet10Mexican(), 'RET10'],
+            'Ret10Foreign' => [self::documentRet10Foreign(), 'RET10'],
         ];
     }
 

--- a/tests/Unit/DiscoverExtractorTest.php
+++ b/tests/Unit/DiscoverExtractorTest.php
@@ -73,7 +73,6 @@ final class DiscoverExtractorTest extends DOMDocumentsTestCase
     }
 
     /**
-     * @param DOMDocument $document
      * @dataProvider providerExpressionOnValidDocuments
      */
     public function testExpressionOnValidDocuments(DOMDocument $document): void
@@ -84,8 +83,6 @@ final class DiscoverExtractorTest extends DOMDocumentsTestCase
     }
 
     /**
-     * @param DOMDocument $document
-     * @param string $type
      * @dataProvider providerExpressionOnValidDocuments
      */
     public function testExtractProducesTheSameResultsAsObtainAndFormat(DOMDocument $document, string $type): void

--- a/tests/Unit/Extractors/Comprobante32Test.php
+++ b/tests/Unit/Extractors/Comprobante32Test.php
@@ -34,11 +34,11 @@ final class Comprobante32Test extends DOMDocumentsTestCase
     }
 
     /** @return array<string, array{DOMDocument}> */
-    public function providerCfdiDifferentVersions(): array
+    public static function providerCfdiDifferentVersions(): array
     {
         return [
-            'CFDI 4.0' => [$this->documentCfdi40()],
-            'CFDI 3.3' => [$this->documentCfdi33()],
+            'CFDI 4.0' => [self::documentCfdi40()],
+            'CFDI 3.3' => [self::documentCfdi33()],
         ];
     }
 

--- a/tests/Unit/Extractors/Comprobante33Test.php
+++ b/tests/Unit/Extractors/Comprobante33Test.php
@@ -34,11 +34,11 @@ final class Comprobante33Test extends DOMDocumentsTestCase
     }
 
     /** @return array<string, array{DOMDocument}> */
-    public function providerCfdiDifferentVersions(): array
+    public static function providerCfdiDifferentVersions(): array
     {
         return [
-            'CFDI 4.0' => [$this->documentCfdi40()],
-            'CFDI 3.2' => [$this->documentCfdi32()],
+            'CFDI 4.0' => [self::documentCfdi40()],
+            'CFDI 3.2' => [self::documentCfdi32()],
         ];
     }
 

--- a/tests/Unit/Extractors/Comprobante40Test.php
+++ b/tests/Unit/Extractors/Comprobante40Test.php
@@ -34,11 +34,11 @@ final class Comprobante40Test extends DOMDocumentsTestCase
     }
 
     /** @return array<string, array{DOMDocument}> */
-    public function providerCfdiDifferentVersions(): array
+    public static function providerCfdiDifferentVersions(): array
     {
         return [
-            'CFDI 3.3' => [$this->documentCfdi33()],
-            'CFDI 3.2' => [$this->documentCfdi32()],
+            'CFDI 3.3' => [self::documentCfdi33()],
+            'CFDI 3.2' => [self::documentCfdi32()],
         ];
     }
 

--- a/tests/Unit/Extractors/Retenciones10Test.php
+++ b/tests/Unit/Extractors/Retenciones10Test.php
@@ -44,11 +44,11 @@ final class Retenciones10Test extends DOMDocumentsTestCase
     }
 
     /** @return array<string, array{DOMDocument}> */
-    public function providerCfdiDifferentVersions(): array
+    public static function providerCfdiDifferentVersions(): array
     {
         return [
-            'RET 2.0 Mexican' => [$this->documentRet20Mexican()],
-            'RET 2.0 Foreign' => [$this->documentRet20Foreign()],
+            'RET 2.0 Mexican' => [self::documentRet20Mexican()],
+            'RET 2.0 Foreign' => [self::documentRet20Foreign()],
         ];
     }
 

--- a/tests/Unit/Extractors/Retenciones20Test.php
+++ b/tests/Unit/Extractors/Retenciones20Test.php
@@ -52,11 +52,11 @@ final class Retenciones20Test extends DOMDocumentsTestCase
     }
 
     /** @return array<string, array{DOMDocument}> */
-    public function providerCfdiDifferentVersions(): array
+    public static function providerCfdiDifferentVersions(): array
     {
         return [
-            'RET 1.0 Mexican' => [$this->documentRet10Mexican()],
-            'RET 1.0 Foreign' => [$this->documentRet10Foreign()],
+            'RET 1.0 Mexican' => [self::documentRet10Mexican()],
+            'RET 1.0 Foreign' => [self::documentRet10Foreign()],
         ];
     }
 

--- a/tests/Unit/Extractors/Standards/FormatTotal10i6dTest.php
+++ b/tests/Unit/Extractors/Standards/FormatTotal10i6dTest.php
@@ -13,7 +13,6 @@ final class FormatTotal10i6dTest extends TestCase
      * Total must be 6 decimals and 17 total length zero padding on left
      *
      * @param string $input total cannot have more than 6 decimals as set in Anexo 20
-     * @param string $expectedFormat
      * @testWith ["123.45",     "0000000123.450000"]
      *           ["0.123456",   "0000000000.123456"]
      *           ["0.1234561",  "0000000000.123456"]

--- a/tests/Unit/Extractors/Standards/FormatTotal18i6dTest.php
+++ b/tests/Unit/Extractors/Standards/FormatTotal18i6dTest.php
@@ -11,7 +11,6 @@ final class FormatTotal18i6dTest extends TestCase
 {
     /**
      * @param string $input total cannot have more than 6 decimals as set in Anexo 20
-     * @param string $expectedFormat
      * @testWith ["123.45", "123.45"]
      *           ["0.123456", "0.123456"]
      *           ["0.1234561", "0.123456"]


### PR DESCRIPTION
Se elimina el soporte para PHP 7.3, PHP 7.4 y PHP 8.0.  La versión mínima es ahora PHP 8.1.
Esto incluye cambios al código relacionados con tipos, calidad de código y eliminación de código muerto.

Los siguientes cambios aplican al entorno de desarrollo.

- Se agrega la herramienta `composer-normalize` al proceso de construcción.
- Se actualiza el estándar de código para `phpcs` y `php-cs-fixer`.